### PR TITLE
Updated install instructions with alternate location of py4j jar file

### DIFF
--- a/py4j-web/install.rst
+++ b/py4j-web/install.rst
@@ -40,7 +40,7 @@ Using easy_install or pip
    location depends on the platform and the installation type. Some likely
    locations are:
 
-   1. ``/usr/share/py4j/py4j0.x.jar`` for system-wide install on Linux.
+   1. ``/usr/share/py4j/py4j0.x.jar`` for system-wide install on Linux. Alternatively, it can be at ``/usr/local/share/py4j/py4j0.x.jar``.
    2. ``{virtual_env_dir}/share/py4j/py4j0.x.jar`` for installation in a
       virtual environment.
    3. ``C:\python27\share\py4j\py4j0.x.jar`` for system-wide install on

--- a/py4j-web/install.rst
+++ b/py4j-web/install.rst
@@ -40,7 +40,7 @@ Using easy_install or pip
    location depends on the platform and the installation type. Some likely
    locations are:
 
-   1. ``/usr/share/py4j/py4j0.x.jar`` or ``/usr/local/share/py4j/py4j0.x.jar`` for system-wide install on Linux.
+   1. Either ``/usr/share/py4j/py4j0.x.jar`` or ``/usr/local/share/py4j/py4j0.x.jar`` for system-wide install on Linux.
    2. ``{virtual_env_dir}/share/py4j/py4j0.x.jar`` for installation in a
       virtual environment.
    3. ``C:\python27\share\py4j\py4j0.x.jar`` for system-wide install on

--- a/py4j-web/install.rst
+++ b/py4j-web/install.rst
@@ -40,7 +40,7 @@ Using easy_install or pip
    location depends on the platform and the installation type. Some likely
    locations are:
 
-   1. ``/usr/share/py4j/py4j0.x.jar`` for system-wide install on Linux. Alternatively, it can be at ``/usr/local/share/py4j/py4j0.x.jar``.
+   1. ``/usr/share/py4j/py4j0.x.jar`` or ``/usr/local/share/py4j/py4j0.x.jar`` for system-wide install on Linux.
    2. ``{virtual_env_dir}/share/py4j/py4j0.x.jar`` for installation in a
       virtual environment.
    3. ``C:\python27\share\py4j\py4j0.x.jar`` for system-wide install on


### PR DESCRIPTION
py4j jar file installs at `/usr/local/share/py4j/` on my system (Ubuntu 14.04) when I use pip install.
Updated install.rst to reflect that.