### PR TITLE
Allow binding on the un predetermined port for the callback server

### DIFF
--- a/py4j-java/ant.properties
+++ b/py4j-java/ant.properties
@@ -27,7 +27,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 # Version of the software
-version=0.9
+version=0.9.1-SNAPSHOT
 
 # Path to the JUnit 4 jar. YOU MUST SET THIS VALUE. Otherwise, the test classes won't compile.
 junit.path=junit-4.10.jar

--- a/py4j-java/pom.xml
+++ b/py4j-java/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>py4j</artifactId>
 	<packaging>jar</packaging>
 	<name>Py4J</name>
-	<version>0.9</version>
+	<version>0.9.1-SNAPSHOT</version>
 	<description>Py4J enables Python programs running in a Python interpreter to dynamically access Java objects in a Java Virtual Machine. Methods are called as if the Java objects resided in the Python interpreter and Java collections can be accessed through standard Python collection methods. Py4J also enables Java programs to call back Python objects.</description>
 	<url>http://www.py4j.org/</url>
 	<licenses>

--- a/py4j-java/src/py4j/CallbackClient.java
+++ b/py4j-java/src/py4j/CallbackClient.java
@@ -54,13 +54,9 @@ import java.util.logging.Logger;
 public class CallbackClient {
 	public final static String DEFAULT_ADDRESS = "127.0.0.1";
 
-	/**
-	 * CallbackClient is only needed to be initialized when JVM invokes python code.
-	 * Until then the value of the port and address is unused and can be changed.
-	 */
-	private int port;
+	private final int port;
 
-	private InetAddress address;
+	private final InetAddress address;
 
 	private final Deque<CallbackConnection> connections = new ArrayDeque<CallbackConnection>();
 
@@ -167,14 +163,6 @@ public class CallbackClient {
 
 	public int getPort() {
 		return port;
-	}
-
-	public void setPort(int port) {
-		this.port = port;
-	}
-
-	public void setAddress(InetAddress address) {
-		this.address = address;
 	}
 
 	private void giveBackConnection(CallbackConnection cc) {

--- a/py4j-java/src/py4j/CallbackClient.java
+++ b/py4j-java/src/py4j/CallbackClient.java
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *
  * Copyright (c) 2009, 2011, Barthelemy Dagenais All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
@@ -47,16 +47,20 @@ import java.util.logging.Logger;
  * are created as needed (e.g., one per concurrent thread) and are closed after
  * a certain time.
  * </p>
- * 
+ *
  * @author Barthelemy Dagenais
- * 
+ *
  */
 public class CallbackClient {
 	public final static String DEFAULT_ADDRESS = "127.0.0.1";
 
-	private final int port;
+	/**
+	 * CallbackClient is only needed to be initialized when JVM invokes python code.
+	 * Until then the value of the port and address is unused and can be changed.
+	 */
+	private int port;
 
-	private final InetAddress address;
+	private InetAddress address;
 
 	private final Deque<CallbackConnection> connections = new ArrayDeque<CallbackConnection>();
 
@@ -100,7 +104,7 @@ public class CallbackClient {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param port
 	 *            The port used by channels to connect to the Python side.
 	 * @param address
@@ -165,6 +169,14 @@ public class CallbackClient {
 		return port;
 	}
 
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public void setAddress(InetAddress address) {
+		this.address = address;
+	}
+
 	private void giveBackConnection(CallbackConnection cc) {
 		try {
 			lock.lock();
@@ -185,12 +197,12 @@ public class CallbackClient {
 	 * Closes communication channels that have not been used for a time
 	 * specified at the creation of the callback client.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * Clients should not directly call this method: it is called by a periodic
 	 * cleaner thread.
 	 * </p>
-	 * 
+	 *
 	 */
 	public void periodicCleanup() {
 		try {
@@ -219,7 +231,7 @@ public class CallbackClient {
 	 * Python proxies to call Python methods or to request the garbage
 	 * collection of a proxy.
 	 * </p>
-	 * 
+	 *
 	 * @param command
 	 *            The command to send.
 	 * @return The response.
@@ -261,7 +273,7 @@ public class CallbackClient {
 	 * <p>
 	 * Closes all active channels, stops the periodic cleanup of channels and
 	 * mark the client as shutting down.
-	 * 
+	 *
 	 * No more commands can be sent after this method has been called,
 	 * <em>except</em> commands that were initiated before the shutdown method
 	 * was called..

--- a/py4j-java/src/py4j/GatewayServer.java
+++ b/py4j-java/src/py4j/GatewayServer.java
@@ -127,9 +127,9 @@ public class GatewayServer extends DefaultGatewayServerListener implements
 
 	private final int port;
 
-	private final int pythonPort;
+	private int pythonPort;
 
-	private final InetAddress pythonAddress;
+	private InetAddress pythonAddress;
 
 	private final Gateway gateway;
 
@@ -142,7 +142,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements
 
 	private final List<Socket> connections = new ArrayList<Socket>();
 
-	private final CallbackClient cbClient;
+	private CallbackClient cbClient;
 
 	private final List<Class<? extends Command>> customCommands;
 
@@ -226,6 +226,17 @@ public class GatewayServer extends DefaultGatewayServerListener implements
 		this.cbClient = new CallbackClient(pythonPort, pythonAddress);
 		this.gateway = new Gateway(entryPoint, cbClient);
 		this.gateway.getBindings().put(GATEWAY_SERVER_ID, this);
+	}
+
+
+	public void resetCallbackClientAddress(InetAddress pythonAddress, int pythonPort) {
+		if (cbClient != null) {
+			cbClient.shutdown();
+		}
+
+		this.cbClient = new CallbackClient(pythonPort, pythonAddress);
+		this.pythonPort = pythonPort;
+		this.pythonAddress = pythonAddress;
 	}
 
 	/**

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -699,7 +699,7 @@ class GatewayConnection(object):
             self.stream = self.socket.makefile("rb", 0)
         except Exception as e:
             msg = "An error occurred while trying to connect to the Java "\
-                "server"
+                "server ({0}:{1})".format(self.address, self.port)
             logger.exception(msg)
             raise Py4JNetworkError(msg, e)
 
@@ -1326,6 +1326,9 @@ class JavaGateway(object):
             self.shutdown()
             raise
 
+    def get_callback_server(self):
+        return self._callback_server
+
     def start_callback_server(self, callback_server_parameters=None):
         """Starts the callback server.
 
@@ -1598,8 +1601,11 @@ class CallbackServer(object):
             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             self.server_socket.bind((self.address, self.port))
+            self._listening_address, self._listening_port = \
+                self.server_socket.getsockname()
         except Exception as e:
-            msg = "An error occurred while trying to start the callback server"
+            msg = "An error occurred while trying to start the callback "\
+                  "server ({0}:{1})".format(self.address, self.port)
             logger.exception(msg)
             raise Py4JNetworkError(msg, e)
 
@@ -1609,6 +1615,12 @@ class CallbackServer(object):
         # Default is False
         self.thread.daemon = self.callback_server_parameters.daemonize
         self.thread.start()
+
+    def get_listening_port(self):
+        return self._listening_port
+
+    def get_listening_address(self):
+        return self._listening_address
 
     def run(self):
         """Starts listening and accepting connection requests.

--- a/py4j-python/src/py4j/version.py
+++ b/py4j-python/src/py4j/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.9'
+__version__ = '0.9.1-SNAPSHOT'

--- a/py4j-web/changelog.rst
+++ b/py4j-web/changelog.rst
@@ -4,6 +4,13 @@ Changelog
 The changelog describes in plain English the changes that occurred between Py4J
 releases.
 
+Py4J 0.9.1-SNAPSHOT
+-------------------
+- Python side: When listening on port 0, allow callbacks to query the actual
+  address and port where the CallbackServer is listening.
+- JVM side: After GatewayServer is already launched, expose an ability to change
+  the address:port where the CallbackClient connects.`
+
 Py4J 0.9
 --------
 


### PR DESCRIPTION
As discussed in #147 -  and do late initialization of the callback client.