### PR TITLE
Fix the issue that PythonProxyHandler.finalize blocks forever

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1738,8 +1738,10 @@ class CallbackConnection(Thread):
                 elif command == proto.GARBAGE_COLLECT_PROXY_COMMAND_NAME:
                     self.input.readline()
                     del(self.pool[obj_id])
+                    self.socket.sendall("y\n".encode("utf-8"))
                 else:
                     logger.error("Unknown command {0}".format(command))
+                    self.socket.sendall(proto.ERROR_RETURN_MESSAGE.encode("utf-8"))
         except Exception:
             # This is a normal exception...
             logger.info(


### PR DESCRIPTION
PythonProxyHandler.finalize uses sendCommand to send the finalizeCommand. Because "CallbackConnection.sendCommand" needs the Python side to send back a return message but the Python side doesn't, it blocks "finalize" forever.

This PR added a "y\n" return message for finalizeCommand to fix this issue.

This issue was found by David Watson in https://issues.apache.org/jira/browse/SPARK-11711