### PR TITLE
Use current thread's context classloader in Class.forName() calls

### DIFF
--- a/py4j-java/src/py4j/Protocol.java
+++ b/py4j-java/src/py4j/Protocol.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 
 import py4j.reflection.PythonProxyHandler;
+import py4j.reflection.ReflectionUtils;
 
 /**
  * <p>
@@ -401,7 +402,7 @@ public class Protocol {
 
 		for (int i = 1; i < length; i++) {
 			try {
-				interfaces[i - 1] = Class.forName(parts[i]);
+				interfaces[i - 1] = ReflectionUtils.classForName(parts[i]);
 				if (!interfaces[i - 1].isInterface()) {
 					throw new Py4JException(
 							"This class "

--- a/py4j-java/src/py4j/commands/HelpPageCommand.java
+++ b/py4j-java/src/py4j/commands/HelpPageCommand.java
@@ -38,6 +38,7 @@ import py4j.Py4JException;
 import py4j.ReturnObject;
 import py4j.model.HelpPageGenerator;
 import py4j.model.Py4JClass;
+import py4j.reflection.ReflectionUtils;
 
 /**
  * <p>
@@ -90,8 +91,8 @@ public class HelpPageCommand extends AbstractCommand {
 		String returnCommand = Protocol.getOutputErrorCommand();
 
 		try {
-			Py4JClass clazz = Py4JClass.buildClass(Class.forName(className),
-					true);
+			Py4JClass clazz = Py4JClass.buildClass(
+					ReflectionUtils.classForName(className), true);
 			boolean isShortName = Protocol.getBoolean(shortName);
 			String helpPage = HelpPageGenerator.getHelpPage(clazz, pattern,
 					isShortName);

--- a/py4j-java/src/py4j/reflection/ReflectionEngine.java
+++ b/py4j-java/src/py4j/reflection/ReflectionEngine.java
@@ -194,7 +194,7 @@ public class ReflectionEngine {
 		Class<?> clazz = null;
 
 		try {
-			clazz = Class.forName(classFQN);
+			clazz = ReflectionUtils.classForName(classFQN);
 		} catch (Exception e) {
 			logger.log(Level.WARNING, "Class FQN does not exist: " + classFQN,
 					e);
@@ -257,7 +257,7 @@ public class ReflectionEngine {
 		Class<?> clazz = null;
 
 		try {
-			clazz = Class.forName(classFQN);
+			clazz = ReflectionUtils.classForName(classFQN);
 		} catch (Exception e) {
 			logger.log(Level.WARNING, "Class FQN does not exist: " + classFQN,
 					e);
@@ -350,7 +350,7 @@ public class ReflectionEngine {
 		Class<?> clazz = null;
 
 		try {
-			clazz = Class.forName(classFQN);
+			clazz = ReflectionUtils.classForName(classFQN);
 		} catch (Exception e) {
 			logger.log(Level.WARNING, "Class FQN does not exist: " + classFQN,
 					e);

--- a/py4j-java/src/py4j/reflection/ReflectionUtils.java
+++ b/py4j-java/src/py4j/reflection/ReflectionUtils.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2011, Barthelemy Dagenais All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+package py4j.reflection;
+
+public class ReflectionUtils {
+  /**
+   * Preferred alternative to {@link Class#forName(String)}, which uses the
+   * current thread's context classloader instead of the root classloader.
+   */
+  public static Class<?> classForName(String className)
+      throws ClassNotFoundException {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    return Class.forName(className, true, classLoader);
+  }
+}

--- a/py4j-java/src/py4j/reflection/TypeUtil.java
+++ b/py4j-java/src/py4j/reflection/TypeUtil.java
@@ -232,7 +232,7 @@ public class TypeUtil {
 	public static Class<?> forName(String fqn) throws ClassNotFoundException {
 		Class<?> clazz = primitiveClasses.get(fqn);
 		if (clazz == null) {
-			clazz = Class.forName(fqn);
+			clazz = ReflectionUtils.classForName(fqn);
 		}
 		return clazz;
 	}
@@ -244,7 +244,7 @@ public class TypeUtil {
 			if (fqn.indexOf('.') < 0) {
 				clazz = getClass(fqn, view);
 			} else {
-				clazz = Class.forName(fqn);
+				clazz = ReflectionUtils.classForName(fqn);
 			}
 		}
 		return clazz;
@@ -256,18 +256,19 @@ public class TypeUtil {
 
 		try {
 			// First, try the fqn
-			clazz = Class.forName(simpleName);
+			clazz = ReflectionUtils.classForName(simpleName);
 		} catch (Exception e) {
 			// Then try the single import
 			Map<String, String> singleImportsMap = view.getSingleImportsMap();
 			String newFQN = singleImportsMap.get(simpleName);
 			if (newFQN != null) {
-				clazz = Class.forName(newFQN);
+				clazz = ReflectionUtils.classForName(newFQN);
 			} else {
 				// Or try star imports
 				for (String starImport : view.getStarImports()) {
 					try {
-						clazz = Class.forName(starImport + "." + simpleName);
+						clazz = ReflectionUtils.classForName(
+								starImport + "." + simpleName);
 						break;
 					} catch (Exception e2) {
 						// Ignore
@@ -409,7 +410,7 @@ public class TypeUtil {
 	public static boolean isInstanceOf(String classFQN, Object object) {
 		Class<?> clazz = null;
 		try {
-			clazz = Class.forName(classFQN);
+			clazz = ReflectionUtils.classForName(classFQN);
 		} catch (Exception e) {
 			throw new Py4JException(e);
 		}


### PR DESCRIPTION
This patch modifies Py4J's Java code to replace all `Class.forName` calls with calls to a static helper method which uses the current thread's context class loader to load classes. 

`Class.forName(className)` loads classes from the root class loader and thus will miss classes that are only available in child class loaders. This has caused problems for us in Apache Spark; see https://issues.apache.org/jira/browse/SPARK-6047 for more details.

This is related to #130 but addresses a narrower set of issues.