### PR TITLE
Fix for issue https://github.com/bartdag/py4j/issues/278

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -14,6 +14,7 @@ Matthew Gerring <matthew.gerring@gmail.com>
 Jonah Graham <jonah@kichwacoders.com>
 Alex Grönholm <alex.gronholm+git@nextday.fi>
 Chris Kanich <ckanich@uic.edu>
+Scott Lewis <scottslewis@gmail.com>
 Chetan Narsude <@243826>
 Josh Rosen <rosenville@gmail.com>
 Isaac Sánchez Barrera <isaac@isb1009.es>

--- a/py4j-java/src/main/java/py4j/reflection/PythonProxyHandler.java
+++ b/py4j-java/src/main/java/py4j/reflection/PythonProxyHandler.java
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
 import py4j.Gateway;
 import py4j.Protocol;
 import py4j.Py4JException;
-import py4j.Py4JJavaException;
 
 /**
  * <p>
@@ -113,11 +112,13 @@ public class PythonProxyHandler implements InvocationHandler {
 
 	private Object convertOutput(Method method, Object output) {
 		Class<?> returnType = method.getReturnType();
-		Class<?> outputType = output.getClass();
-		if (returnType.equals(Void.TYPE)) {
+		// If output is None/null or expected return type is 
+		// Void then return output with no conversion
+		if (output == null || returnType.equals(Void.TYPE)) {
 			// Do not convert void
 			return output;
 		}
+		Class<?> outputType = output.getClass();
 		Class<?>[] parameters = { returnType };
 		Class<?>[] arguments = { outputType };
 		List<TypeConverter> converters = new ArrayList<TypeConverter>();

--- a/py4j-java/src/test/java/py4j/examples/IReturnConverter.java
+++ b/py4j-java/src/test/java/py4j/examples/IReturnConverter.java
@@ -39,4 +39,5 @@ public interface IReturnConverter {
 
 	void doNothing();
 
+	Object getNull();
 }

--- a/py4j-java/src/test/java/py4j/examples/ReturnerExample.java
+++ b/py4j-java/src/test/java/py4j/examples/ReturnerExample.java
@@ -46,4 +46,8 @@ public class ReturnerExample {
 	public int computeNothing(IReturnConverter returner) {
 		return 1;
 	}
+	
+	public Object computeNull(IReturnConverter returner) {
+		return returner.getNull();
+	}
 }

--- a/py4j-python/src/py4j/tests/java_callback_test.py
+++ b/py4j-python/src/py4j/tests/java_callback_test.py
@@ -119,6 +119,9 @@ class Returner(object):
     def doNothing(self):
         print("Doing nothing")
 
+    def getNull(self):
+        return None
+    
     class Java:
         implements = ["py4j.examples.IReturnConverter"]
 
@@ -317,6 +320,13 @@ class IntegrationTest(unittest.TestCase):
         returner = Returner()
         output = example.computeNothing(returner)
         self.assertEqual(output, 1)
+
+    def testProxyReturnerNull(self):
+        sleep()
+        example = self.gateway.jvm.py4j.examples.ReturnerExample()
+        returner = Returner()
+        output = example.computeNull(returner)
+        self.assertEqual(output, None)
 
     def testProxy(self):
         sleep()


### PR DESCRIPTION
PythonProxyHandler class (java).  Also enhanced java_callback_test.py to
test.  Without fix to PythonProxyHandler new test fails, with fix
succeeds.  see IntegrationTest.testProxyReturnerNull