### PR TITLE
Add GatewayServer constructor to allow for customized Gateway (osgi)

### DIFF
--- a/py4j-java/src/main/java/py4j/CallbackClient.java
+++ b/py4j-java/src/main/java/py4j/CallbackClient.java
@@ -373,9 +373,9 @@ public class CallbackClient implements Py4JPythonClient {
 	}
 
 	@Override
-	public Object getPythonServerEntryPoint(Gateway gateway, Class[] interfacesToImplement) {
-		Object proxy = Protocol.getPythonProxyHandler(ReflectionUtil.getClassLoader(), interfacesToImplement,
-				Protocol.ENTRY_POINT_OBJECT_ID, gateway);
+	public Object getPythonServerEntryPoint(Gateway gateway, @SuppressWarnings("rawtypes") Class[] interfacesToImplement) {
+		Object proxy = gateway.createProxy(ReflectionUtil.getClassLoader(), interfacesToImplement,
+				Protocol.ENTRY_POINT_OBJECT_ID);
 		return proxy;
 	}
 

--- a/py4j-java/src/main/java/py4j/Gateway.java
+++ b/py4j-java/src/main/java/py4j/Gateway.java
@@ -30,6 +30,7 @@
 package py4j;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -43,6 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
 import py4j.reflection.MethodInvoker;
+import py4j.reflection.PythonProxyHandler;
 import py4j.reflection.ReflectionEngine;
 
 /**
@@ -349,6 +351,13 @@ public class Gateway {
 		this.isStarted = isStarted;
 	}
 
+	public Object createProxy(ClassLoader classLoader, @SuppressWarnings("rawtypes") Class[] interfacesToImplement, String objectId) {
+		return Proxy.newProxyInstance(classLoader, interfacesToImplement, createPythonProxyHandler(objectId));
+	}
+	
+	protected PythonProxyHandler createPythonProxyHandler(String id) {
+		return new PythonProxyHandler(id, this);
+	}
 	/**
 	 * <p>
 	 * Releases all objects that were referenced by this Gateway and shuts

--- a/py4j-java/src/main/java/py4j/Gateway.java
+++ b/py4j-java/src/main/java/py4j/Gateway.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
-import py4j.reflection.ClassLoadingStrategy;
 import py4j.reflection.MethodInvoker;
 import py4j.reflection.PythonProxyHandler;
 import py4j.reflection.ReflectionEngine;
@@ -392,10 +391,6 @@ public class Gateway {
 			bindings.put(Protocol.ENTRY_POINT_OBJECT_ID, entryPoint);
 		}
 		bindings.put(Protocol.DEFAULT_JVM_OBJECT_ID, defaultJVMView);
-	}
-
-	public ClassLoadingStrategy getClassLoadingStrategy() {
-		return null;
 	}
 
 }

--- a/py4j-java/src/main/java/py4j/Gateway.java
+++ b/py4j-java/src/main/java/py4j/Gateway.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Logger;
 
+import py4j.reflection.ClassLoadingStrategy;
 import py4j.reflection.MethodInvoker;
 import py4j.reflection.PythonProxyHandler;
 import py4j.reflection.ReflectionEngine;
@@ -391,6 +392,10 @@ public class Gateway {
 			bindings.put(Protocol.ENTRY_POINT_OBJECT_ID, entryPoint);
 		}
 		bindings.put(Protocol.DEFAULT_JVM_OBJECT_ID, defaultJVMView);
+	}
+
+	public ClassLoadingStrategy getClassLoadingStrategy() {
+		return null;
 	}
 
 }

--- a/py4j-java/src/main/java/py4j/GatewayServer.java
+++ b/py4j-java/src/main/java/py4j/GatewayServer.java
@@ -427,6 +427,35 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		this.sSocketFactory = sSocketFactory;
 	}
 
+	/*
+	 * @param gateway gateway instance (or subclass).  Must not be <code>null</code>.
+	 * @param port the host port to usu
+	 * @param address the host address to use
+	 * @param connectTimeout the connect timeout (ms)
+	 * @param readTimeout the read timeout (ms)
+	 * @param customCommands any customCommands to use.  May be <code>null</code>
+	 * @param sSocketFactory socketFactory to use.  Must not be <code>null</code>
+	 */
+	public GatewayServer(Gateway gateway, int port, InetAddress address, int connectTimeout, int readTimeout,
+			List<Class<? extends Command>> customCommands, ServerSocketFactory sSocketFactory) {
+		super();
+		this.port = port;
+		this.address = address;
+		this.connectTimeout = connectTimeout;
+		this.readTimeout = readTimeout;
+		this.gateway = gateway;
+		this.pythonPort = gateway.getCallbackClient().getPort();
+		this.pythonAddress = gateway.getCallbackClient().getAddress();
+		this.gateway.putObject(GATEWAY_SERVER_ID, this);
+		if (customCommands != null) {
+			this.customCommands = customCommands;
+		} else {
+			this.customCommands = new ArrayList<Class<? extends Command>>();
+		}
+		this.listeners = new CopyOnWriteArrayList<GatewayServerListener>();
+		this.sSocketFactory = sSocketFactory;
+	}
+
 	public void addListener(GatewayServerListener listener) {
 		listeners.addIfAbsent(listener);
 	}
@@ -754,7 +783,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	 * @param interfacesToImplement
 	 * @return
 	 */
-	public Object getPythonServerEntryPoint(Class[] interfacesToImplement) {
+	public Object getPythonServerEntryPoint(@SuppressWarnings("rawtypes") Class[] interfacesToImplement) {
 		return getCallbackClient().getPythonServerEntryPoint(gateway, interfacesToImplement);
 	}
 

--- a/py4j-java/src/main/java/py4j/Protocol.java
+++ b/py4j-java/src/main/java/py4j/Protocol.java
@@ -34,6 +34,8 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 
+import py4j.reflection.ClassLoadingStrategy;
+import py4j.reflection.CurrentThreadClassLoadingStrategy;
 import py4j.reflection.ReflectionUtil;
 
 /**
@@ -400,9 +402,16 @@ public class Protocol {
 			throw new Py4JException("Invalid Python Proxy.");
 		}
 
+	    ClassLoadingStrategy classLoadingStrategy = gateway.getClassLoadingStrategy();
+	    if (classLoadingStrategy == null) 
+	        classLoadingStrategy = ReflectionUtil.getClassLoadingStrategy();
+	    // Just in case
+	    if (classLoadingStrategy == null)
+	        classLoadingStrategy = new CurrentThreadClassLoadingStrategy();
+
 		for (int i = 1; i < length; i++) {
 			try {
-				interfaces[i - 1] = ReflectionUtil.classForName(parts[i]);
+				interfaces[i - 1] = classLoadingStrategy.classForName(parts[i]);
 				if (!interfaces[i - 1].isInterface()) {
 					throw new Py4JException(
 							"This class " + parts[i] + " is not an interface and cannot be used as a Python Proxy.");

--- a/py4j-java/src/main/java/py4j/Protocol.java
+++ b/py4j-java/src/main/java/py4j/Protocol.java
@@ -34,8 +34,6 @@ import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 
-import py4j.reflection.ClassLoadingStrategy;
-import py4j.reflection.CurrentThreadClassLoadingStrategy;
 import py4j.reflection.ReflectionUtil;
 
 /**
@@ -402,16 +400,9 @@ public class Protocol {
 			throw new Py4JException("Invalid Python Proxy.");
 		}
 
-	    ClassLoadingStrategy classLoadingStrategy = gateway.getClassLoadingStrategy();
-	    if (classLoadingStrategy == null) 
-	        classLoadingStrategy = ReflectionUtil.getClassLoadingStrategy();
-	    // Just in case
-	    if (classLoadingStrategy == null)
-	        classLoadingStrategy = new CurrentThreadClassLoadingStrategy();
-
 		for (int i = 1; i < length; i++) {
 			try {
-				interfaces[i - 1] = classLoadingStrategy.classForName(parts[i]);
+				interfaces[i - 1] = ReflectionUtil.classForName(parts[i]);
 				if (!interfaces[i - 1].isInterface()) {
 					throw new Py4JException(
 							"This class " + parts[i] + " is not an interface and cannot be used as a Python Proxy.");

--- a/py4j-java/src/main/java/py4j/Protocol.java
+++ b/py4j-java/src/main/java/py4j/Protocol.java
@@ -32,10 +32,8 @@ package py4j;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 
-import py4j.reflection.PythonProxyHandler;
 import py4j.reflection.ReflectionUtil;
 
 /**
@@ -414,14 +412,7 @@ public class Protocol {
 			}
 		}
 
-		Object proxy = getPythonProxyHandler(ReflectionUtil.getClassLoader(), interfaces, parts[0], gateway);
-
-		return proxy;
-	}
-
-	public static Object getPythonProxyHandler(ClassLoader classLoader, Class[] interfacesToImplement, String objectId,
-			Gateway gateway) {
-		return Proxy.newProxyInstance(classLoader, interfacesToImplement, new PythonProxyHandler(objectId, gateway));
+		return gateway.createProxy(ReflectionUtil.getClassLoader(), interfaces, parts[0]);
 	}
 
 	/**

--- a/py4j-java/src/test/java/py4j/examples/ReturnerExample.java
+++ b/py4j-java/src/test/java/py4j/examples/ReturnerExample.java
@@ -46,7 +46,7 @@ public class ReturnerExample {
 	public int computeNothing(IReturnConverter returner) {
 		return 1;
 	}
-
+	
 	public Object computeNull(IReturnConverter returner) {
 		return returner.getNull();
 	}

--- a/py4j-python/src/py4j/tests/java_callback_test.py
+++ b/py4j-python/src/py4j/tests/java_callback_test.py
@@ -121,7 +121,7 @@ class Returner(object):
 
     def getNull(self):
         return None
-
+    
     class Java:
         implements = ["py4j.examples.IReturnConverter"]
 


### PR DESCRIPTION
For usage in OSGi, it will be very helpful to add a GatewayServer constructor with the following signature:

	public GatewayServer(Gateway gateway, int port, InetAddress address, int connectTimeout, int readTimeout,List<Class<? extends Command>> customCommands, ServerSocketFactory sSocketFactory) 

This will allow the use of an subclass of the Gateway class, so that the Gateway may be customized.  One way that this will be used in OSGi environment is to subclass Gateway to allow for the customization of proxy creation...doing the 'appropriate thing'...wrt classloading and etc...from within OSGi environment (where there is more than one relevant classloader).

This is a new GatewayServer constructor/entry point so is very unlikely to introduce problems with existing code.  All tests pass with this addition.  There are a couple small additions of annotations to prevent compiler warnings (@SuppressWarnings)

