### PR TITLE
Add support for auth tokens to gateway and callback connections.

### DIFF
--- a/py4j-java/src/main/java/py4j/CallbackClient.java
+++ b/py4j-java/src/main/java/py4j/CallbackClient.java
@@ -91,6 +91,8 @@ public class CallbackClient implements Py4JPythonClient {
 
 	protected final int readTimeout;
 
+	protected final String authToken;
+
 	public CallbackClient(int port) {
 		this(port, GatewayServer.defaultAddress(), DEFAULT_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME_UNIT,
 				SocketFactory.getDefault(), true);
@@ -98,6 +100,11 @@ public class CallbackClient implements Py4JPythonClient {
 
 	public CallbackClient(int port, InetAddress address) {
 		this(port, address, DEFAULT_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME_UNIT);
+	}
+
+	public CallbackClient(int port, InetAddress address, String authToken) {
+		this(port, address, authToken, DEFAULT_MIN_CONNECTION_TIME, DEFAULT_MIN_CONNECTION_TIME_UNIT,
+				SocketFactory.getDefault(), true, GatewayServer.DEFAULT_READ_TIMEOUT);
 	}
 
 	public CallbackClient(int port, InetAddress address, long minConnectionTime, TimeUnit minConnectionTimeUnit) {
@@ -170,6 +177,37 @@ public class CallbackClient implements Py4JPythonClient {
 	 */
 	public CallbackClient(int port, InetAddress address, long minConnectionTime, TimeUnit minConnectionTimeUnit,
 			SocketFactory socketFactory, boolean enableMemoryManagement, int readTimeout) {
+		this(port, address, null, minConnectionTime, minConnectionTimeUnit, socketFactory, enableMemoryManagement,
+				readTimeout);
+	}
+
+	/**
+	 *
+	 * @param port
+	 *            The port used by channels to connect to the Python side.
+	 * @param address
+	 *            The addressed used by channels to connect to the Python side.
+	 * @param authToken
+	 *            Token for authenticating with the callback server.
+	 * @param minConnectionTime
+	 *            The minimum connection time: channels are guaranteed to stay
+	 *            connected for this time after sending a command.
+	 * @param minConnectionTimeUnit
+	 *            The minimum coonnection time unit.
+	 * @param socketFactory
+	 *            The non-{@code null} factory to make {@link Socket}s.
+	 * @param enableMemoryManagement
+	 *            If False, we do not send tell the Python side when a PythonProxy
+	 *            is no longer used by the Java side.
+	 * @param readTimeout
+	 *            Time in milliseconds (0 = infinite). Once a Python program is
+	 *            connected, if a GatewayServer does not receive a request
+	 *            (e.g., a method call) after this time, the connection with the
+	 *            Python program is closed.
+	 */
+	public CallbackClient(int port, InetAddress address, String authToken, long minConnectionTime,
+			TimeUnit minConnectionTimeUnit, SocketFactory socketFactory, boolean enableMemoryManagement,
+			int readTimeout) {
 		super();
 		this.port = port;
 		this.address = address;
@@ -178,6 +216,7 @@ public class CallbackClient implements Py4JPythonClient {
 		this.socketFactory = socketFactory;
 		this.enableMemoryManagement = enableMemoryManagement;
 		this.readTimeout = readTimeout;
+		this.authToken = StringUtil.escape(authToken);
 		setupCleaner();
 	}
 
@@ -195,7 +234,7 @@ public class CallbackClient implements Py4JPythonClient {
 
 		connection = connections.pollLast();
 		if (connection == null) {
-			connection = new CallbackConnection(port, address, socketFactory, readTimeout);
+			connection = new CallbackConnection(port, address, socketFactory, readTimeout, authToken);
 			connection.start();
 		}
 
@@ -249,7 +288,8 @@ public class CallbackClient implements Py4JPythonClient {
 	 */
 	@Override
 	public Py4JPythonClient copyWith(InetAddress pythonAddress, int pythonPort) {
-		return new CallbackClient(pythonPort, pythonAddress, minConnectionTime, minConnectionTimeUnit, socketFactory);
+		return new CallbackClient(pythonPort, pythonAddress, authToken, minConnectionTime, minConnectionTimeUnit,
+				socketFactory, enableMemoryManagement, readTimeout);
 	}
 
 	protected void giveBackConnection(Py4JClientConnection cc) {

--- a/py4j-java/src/main/java/py4j/CallbackConnection.java
+++ b/py4j-java/src/main/java/py4j/CallbackConnection.java
@@ -47,9 +47,9 @@ import javax.net.SocketFactory;
  * Default implementation of the CommunicationChannel interface using TCP
  * sockets.
  * </p>
- * 
+ *
  * @author Barthelemy Dagenais
- * 
+ *
  */
 public class CallbackConnection implements Py4JClientConnection {
 
@@ -74,6 +74,8 @@ public class CallbackConnection implements Py4JClientConnection {
 
 	private final int nonBlockingReadTimeout;
 
+	private final String authToken;
+
 	public CallbackConnection(int port, InetAddress address) {
 		this(port, address, SocketFactory.getDefault());
 	}
@@ -94,6 +96,23 @@ public class CallbackConnection implements Py4JClientConnection {
 	 *            must absolutely be non-blocking.
 	 */
 	public CallbackConnection(int port, InetAddress address, SocketFactory socketFactory, int readTimeout) {
+		this(port, address, socketFactory, readTimeout, null);
+	}
+
+	/**
+	 *
+	 * @param port The port used to connect to the Python side.
+	 * @param address The address used to connect to the Java side.
+	 * @param socketFactory The socket factory used to create a socket (connection) to the Python side.
+	 * @param readTimeout
+	 *            Time in milliseconds (0 = infinite). Once connected to the Python side,
+	 *            if the Java side does not receive a response after this time, the connection with the Python
+	 *            program is closed. If readTimeout = 0, a default readTimeout of 1000 is used for operations that
+	 *            must absolutely be non-blocking.
+	 * @param authToken Token for authenticating with the callback server.
+	 */
+	public CallbackConnection(int port, InetAddress address, SocketFactory socketFactory, int readTimeout,
+			String authToken) {
 		super();
 		this.port = port;
 		this.address = address;
@@ -104,6 +123,7 @@ public class CallbackConnection implements Py4JClientConnection {
 		} else {
 			this.nonBlockingReadTimeout = DEFAULT_NONBLOCKING_SO_TIMEOUT;
 		}
+		this.authToken = authToken;
 	}
 
 	public String sendCommand(String command) {
@@ -207,6 +227,18 @@ public class CallbackConnection implements Py4JClientConnection {
 		socket.setSoTimeout(blockingReadTimeout);
 		reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), Charset.forName("UTF-8")));
 		writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), Charset.forName("UTF-8")));
+
+		if (authToken != null) {
+			writer.write(authToken);
+			writer.write("\n");
+			writer.flush();
+
+			String reply = reader.readLine();
+			if (reply == null || !reply.equals(Protocol.getOutputSuccessCommand().trim())) {
+				shutdown(true);
+				throw new IOException("Authentication with callback server unsuccessful.");
+			}
+		}
 	}
 
 	public boolean wasUsed() {

--- a/py4j-java/src/main/java/py4j/GatewayServer.java
+++ b/py4j-java/src/main/java/py4j/GatewayServer.java
@@ -38,6 +38,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -153,6 +154,8 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	private final CopyOnWriteArrayList<GatewayServerListener> listeners;
 
 	private final ServerSocketFactory sSocketFactory;
+
+	private final String authToken;
 
 	private ServerSocket sSocket;
 
@@ -409,6 +412,12 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	public GatewayServer(Object entryPoint, int port, InetAddress address, int connectTimeout, int readTimeout,
 			List<Class<? extends Command>> customCommands, Py4JPythonClient cbClient,
 			ServerSocketFactory sSocketFactory) {
+		this(entryPoint, port, address, connectTimeout, readTimeout, customCommands, cbClient, sSocketFactory, null);
+	}
+
+	private GatewayServer(Object entryPoint, int port, InetAddress address, int connectTimeout, int readTimeout,
+			List<Class<? extends Command>> customCommands, Py4JPythonClient cbClient,
+			ServerSocketFactory sSocketFactory, String authToken) {
 		super();
 		this.port = port;
 		this.address = address;
@@ -425,9 +434,10 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		}
 		this.listeners = new CopyOnWriteArrayList<GatewayServerListener>();
 		this.sSocketFactory = sSocketFactory;
+		this.authToken = StringUtil.escape(authToken);
 	}
 
-	/*
+	/**
 	 * @param gateway gateway instance (or subclass).  Must not be <code>null</code>.
 	 * @param port the host port to usu
 	 * @param address the host address to use
@@ -438,6 +448,11 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	 */
 	public GatewayServer(Gateway gateway, int port, InetAddress address, int connectTimeout, int readTimeout,
 			List<Class<? extends Command>> customCommands, ServerSocketFactory sSocketFactory) {
+		this(gateway, port, address, connectTimeout, readTimeout, customCommands, sSocketFactory, null);
+	}
+
+	private GatewayServer(Gateway gateway, int port, InetAddress address, int connectTimeout, int readTimeout,
+			List<Class<? extends Command>> customCommands, ServerSocketFactory sSocketFactory, String authToken) {
 		super();
 		this.port = port;
 		this.address = address;
@@ -454,6 +469,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		}
 		this.listeners = new CopyOnWriteArrayList<GatewayServerListener>();
 		this.sSocketFactory = sSocketFactory;
+		this.authToken = authToken;
 	}
 
 	public void addListener(GatewayServerListener listener) {
@@ -483,7 +499,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	 * @throws IOException
 	 */
 	protected Py4JServerConnection createConnection(Gateway gateway, Socket socket) throws IOException {
-		GatewayConnection connection = new GatewayConnection(gateway, socket, customCommands, listeners);
+		GatewayConnection connection = new GatewayConnection(gateway, socket, authToken, customCommands, listeners);
 		connection.startConnection();
 		return connection;
 	}
@@ -793,27 +809,56 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 	 * The listening port is printed to stdout so that clients can start
 	 * servers on ephemeral ports.
 	 * </p>
+	 *
+	 * <p>
+	 * If authentication is enabled, the server will create an auth secret with 256 bits of entropy
+	 * and print it to stdout after the server port. Clients should then provide this secret when
+	 * connecting to the server. Note that no second line of output is printed if authentication is
+	 * not enabled.
+	 * </p>
 	 */
 	public static void main(String[] args) {
 		int port;
 		boolean dieOnBrokenPipe = false;
-		String usage = "usage: [--die-on-broken-pipe] port";
+		boolean enableAuth = false;
+		String usage = "usage: [--die-on-broken-pipe] [--enable-auth] port";
+
 		if (args.length == 0) {
 			System.err.println(usage);
 			System.exit(1);
-		} else if (args.length == 2) {
-			if (!args[0].equals("--die-on-broken-pipe")) {
+		}
+
+		for (int i = 0; i < args.length - 1; i++) {
+			String opt = args[i];
+			if (opt.equals("--die-on-broken-pipe")) {
+				dieOnBrokenPipe = true;
+			} else if (opt.equals("--enable-auth")) {
+				enableAuth = true;
+			} else {
 				System.err.println(usage);
 				System.exit(1);
 			}
-			dieOnBrokenPipe = true;
 		}
+
 		port = Integer.parseInt(args[args.length - 1]);
-		GatewayServer gatewayServer = new GatewayServer(null, port);
+
+		String authToken = null;
+		if (enableAuth) {
+			SecureRandom rnd = new SecureRandom();
+			byte[] token = new byte[256 / Byte.SIZE];
+			rnd.nextBytes(token);
+			authToken = Base64.encodeToString(token, false);
+		}
+
+		GatewayServer gatewayServer = new GatewayServerBuilder().javaPort(port).authToken(authToken).build();
 		gatewayServer.start();
 		/* Print out the listening port so that clients can discover it. */
 		int listening_port = gatewayServer.getListeningPort();
 		System.out.println("" + listening_port);
+
+		if (authToken != null) {
+			System.out.println(authToken);
+		}
 
 		if (dieOnBrokenPipe) {
 			/* Exit on EOF or broken pipe.  This ensures that the server dies
@@ -858,6 +903,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		private Object entryPoint;
 		private Py4JPythonClient callbackClient;
 		private List<Class<? extends Command>> customCommands;
+		private String authToken;
 
 		public GatewayServerBuilder() {
 			this(null);
@@ -886,10 +932,10 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 					callbackClient = new CallbackClient(GatewayServer.DEFAULT_PYTHON_PORT);
 				}
 				return new GatewayServer(entryPoint, javaPort, javaAddress, connectTimeout, readTimeout, customCommands,
-						callbackClient, serverSocketFactory);
+						callbackClient, serverSocketFactory, authToken);
 			} else {
 				return new GatewayServer(gateway, javaPort, javaAddress, connectTimeout, readTimeout, customCommands,
-						serverSocketFactory);
+						serverSocketFactory, authToken);
 			}
 		}
 
@@ -910,6 +956,16 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 
 		public GatewayServerBuilder callbackClient(int pythonPort, InetAddress pythonAddress) {
 			callbackClient = new CallbackClient(pythonPort, pythonAddress);
+			return this;
+		}
+
+		/**
+		 * Set up the callback client to talk to the server running at the given address and port,
+		 * authenticating with the given token. If the token is null, no authentication will be
+		 * attempted.
+		 */
+		public GatewayServerBuilder callbackClient(int pythonPort, InetAddress pythonAddress, String authToken) {
+			callbackClient = new CallbackClient(pythonPort, pythonAddress, authToken);
 			return this;
 		}
 
@@ -940,6 +996,15 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 
 		public GatewayServerBuilder customCommands(List<Class<? extends Command>> customCommands) {
 			this.customCommands = customCommands;
+			return this;
+		}
+
+		/**
+		 * Authentication token that clients must provide to the server when connecting. If null,
+		 * authentication is disabled.
+		 */
+		public GatewayServerBuilder authToken(String authToken) {
+			this.authToken = authToken;
 			return this;
 		}
 	}

--- a/py4j-java/src/main/java/py4j/Protocol.java
+++ b/py4j-java/src/main/java/py4j/Protocol.java
@@ -331,6 +331,10 @@ public class Protocol {
 		return ERROR_COMMAND;
 	}
 
+	public final static String getOutputSuccessCommand() {
+		return "" + RETURN_MESSAGE + SUCCESS + END_OUTPUT;
+	}
+
 	public final static String getOutputErrorCommand(String errorMessage) {
 		StringBuilder builder = new StringBuilder();
 		builder.append(RETURN_MESSAGE);

--- a/py4j-java/src/main/java/py4j/StringUtil.java
+++ b/py4j-java/src/main/java/py4j/StringUtil.java
@@ -33,16 +33,20 @@ package py4j;
  * <p>
  * String utility class providing operations to escape and unescape new lines.
  * </p>
- * 
+ *
  * @author Barthelemy Dagenais
- * 
+ *
  */
 public class StringUtil {
 
 	public final static char ESCAPE_CHAR = '\\';
 
 	public static String escape(String original) {
-		return original.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n");
+		if (original != null) {
+			return original.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n");
+		} else {
+			return null;
+		}
 	}
 
 	public static String unescape(String escaped) {

--- a/py4j-java/src/test/java/py4j/GatewayServerTest.java
+++ b/py4j-java/src/test/java/py4j/GatewayServerTest.java
@@ -31,12 +31,22 @@ package py4j;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.Test;
+
+import py4j.commands.HelpPageCommand;
 
 public class GatewayServerTest {
 
@@ -123,6 +133,68 @@ public class GatewayServerTest {
 		assertEquals(pythonPort, GatewayServer.DEFAULT_PYTHON_PORT + 1);
 		assertEquals(pythonAddress, server.getAddress());
 		server.shutdown(true);
+	}
+
+	@Test
+	public void testAuthentication() throws Exception {
+		GatewayServer server = new GatewayServer.GatewayServerBuilder().authToken("secret").build();
+		server.start(true);
+
+		try {
+			Socket valid = new Socket(server.getAddress(), server.getListeningPort());
+			try {
+				testServerAccess(valid, "secret");
+			} finally {
+				valid.close();
+			}
+
+			for (String invalidSecret : Arrays.asList("invalidSecret", null)) {
+				Socket conn = new Socket(server.getAddress(), server.getListeningPort());
+				try {
+					testServerAccess(conn, invalidSecret);
+					fail("Should have failed to communicate with server.");
+				} catch (IOException ioe) {
+					// Expected.
+				} finally {
+					conn.close();
+				}
+			}
+		} finally {
+			server.shutdown(true);
+		}
+	}
+
+	private void testServerAccess(Socket s, String authToken) throws Exception {
+		PrintWriter out = new PrintWriter(new OutputStreamWriter(s.getOutputStream(), "UTF-8"));
+		BufferedReader in = new BufferedReader(new InputStreamReader(s.getInputStream(), "UTF-8"));
+
+		if (authToken != null) {
+			out.println(authToken);
+			out.flush();
+
+			// Read the response from the auth request. Don't check it - let the rest of the test
+			// make sure auth was successful or not.
+			in.readLine();
+		}
+
+		// Send a "help" command and try to read the response. This should throw exceptions if
+		// authentication fails.
+		out.println(HelpPageCommand.HELP_COMMAND_NAME);
+		out.println(HelpPageCommand.HELP_CLASS_SUB_COMMAND_NAME);
+		out.println(HelpPageCommand.class.getName());
+		out.println("");
+		out.println("t");
+		out.flush();
+
+		String reply = in.readLine();
+		if (authToken == null) {
+			// If no auth token was provided, this code might be able to read a line of output before the
+			// socket is closed by the server; it should be the error message from the auth check.
+			assertEquals(Protocol.getOutputErrorCommand().trim(), reply);
+
+			// Throw an IOException since that's what the test above expects in this case.
+			throw new IOException("Auth unsuccessful.");
+		}
 	}
 
 }

--- a/py4j-java/src/test/java/py4j/examples/ExampleApplication.java
+++ b/py4j-java/src/test/java/py4j/examples/ExampleApplication.java
@@ -61,8 +61,14 @@ public class ExampleApplication {
 	public static class ExamplePythonEntryPointApplication {
 
 		public static void main(String[] args) {
+			String authToken = null;
+			if (args.length > 0) {
+				authToken = args[0];
+			}
 			GatewayServer.turnLoggingOff();
-			GatewayServer server = new GatewayServer();
+			GatewayServer server = new GatewayServer.GatewayServerBuilder()
+					.callbackClient(GatewayServer.DEFAULT_PYTHON_PORT, GatewayServer.defaultAddress(), authToken)
+					.build();
 			server.start();
 			IHello hello = (IHello) server.getPythonServerEntryPoint(new Class[] { IHello.class });
 			try {

--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -181,8 +181,11 @@ def escape_new_line(original):
 
     :rtype: an escaped string
     """
-    return smart_decode(original).replace("\\", "\\\\").replace("\r", "\\r").\
-        replace("\n", "\\n")
+    if original:
+        return smart_decode(original).replace("\\", "\\\\").\
+            replace("\r", "\\r").replace("\n", "\\n")
+    else:
+        return original
 
 
 def unescape_new_line(escaped):
@@ -196,11 +199,14 @@ def unescape_new_line(escaped):
 
     :rtype: the original string
     """
-    return ESCAPE_CHAR.join(
-        "\n".join(
-            ("\r".join(p.split(ESCAPE_CHAR + "r")))
-            .split(ESCAPE_CHAR + "n"))
-        for p in escaped.split(ESCAPE_CHAR + ESCAPE_CHAR))
+    if escaped:
+        return ESCAPE_CHAR.join(
+            "\n".join(
+                ("\r".join(p.split(ESCAPE_CHAR + "r")))
+                .split(ESCAPE_CHAR + "n"))
+            for p in escaped.split(ESCAPE_CHAR + ESCAPE_CHAR))
+    else:
+        return escaped
 
 
 def smart_decode(s):

--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -1100,6 +1100,32 @@ class GatewayLauncherTest(unittest.TestCase):
             os.unlink(outpath)
             os.unlink(errpath)
 
+    def testGatewayAuth(self):
+        self.gateway = JavaGateway.launch_gateway(enable_auth=True)
+
+        # Make sure the default client can connect to the server.
+        klass = self.gateway.jvm.java.lang.String
+        help_page = self.gateway.help(klass, short_name=True, display=False)
+        self.assertTrue(len(help_page) > 1)
+
+        # Replace the client with one that does not authenticate.
+        # Make sure it fails.
+        bad_client = GatewayClient(gateway_parameters=GatewayParameters(
+            address=self.gateway.gateway_parameters.address,
+            port=self.gateway.gateway_parameters.port))
+        self.gateway.set_gateway_client(bad_client)
+        try:
+            self.gateway.help(klass, short_name=True, display=False)
+            self.fail("Expected failure to communicate with gateway server.")
+        except Exception:
+            # Expected
+            pass
+        finally:
+            # Restore a good client. This allows the gateway to be shut down.
+            good_client = GatewayClient(
+                gateway_parameters=self.gateway.gateway_parameters)
+            self.gateway.set_gateway_client(good_client)
+
 
 class WaitOperator(object):
 


### PR DESCRIPTION
This change adds authentication to both the gateway and callback
servers, in the form of a shared authentication token.

The generation and distribution of tokens is left for applications
to do. The library just provides the means for enforcing the tokens.
The only exception is when using the gateway server command line,
in which case it will generate a token when requested.

By default, like previously, there is no authentication.

The auth protocol is very, very simple: when auth is enabled, the
servers expect the first line of content from the client connection
to be the auth token. If the token doesn't match, the server will
shut down the connection. Note this means that the token is sent
in plain text over the connection, meaning that for security it
requires the use of a local socket, or SSL for remote sockets.

Fixes #268