### PR TITLE
Fix the syntax error of python example code in index page

### DIFF
--- a/py4j-web/index.rst
+++ b/py4j-web/index.rst
@@ -26,7 +26,7 @@ generated numbers.
   >>> print(number1, number2)
   (2, 7)
   >>> addition_app = gateway.entry_point               # get the AdditionApplication instance
-  >>> value = addition_app.addition(number1, number2)) # call the addition method
+  >>> value = addition_app.addition(number1, number2) # call the addition method
   >>> print(value)
   9
 


### PR DESCRIPTION
A quick fix for the document and everyone can run the example with these fixed code.