### PR TITLE
JavaGateway.help: Fix deprecation warning in py3.6

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -2059,9 +2059,9 @@ class JavaGateway(object):
             will be generated.
 
         :param pattern: Star-pattern used to filter the members. For example
-            "get\*Foo" may return getMyFoo, getFoo, getFooBar, but not
+            "get\\*Foo" may return getMyFoo, getFoo, getFooBar, but not
             bargetFoo. The pattern is matched against the entire signature.
-            To match only the name of a method, use "methodName(\*".
+            To match only the name of a method, use "methodName(\\*".
 
         :param short_name: If True, only the simple name of the parameter
             types and return types will be displayed. If False, the fully


### PR DESCRIPTION
In py3.6, a backslash-character pair that is not a valid escape
sequence now generates a DeprecationWarning. This will later be
converted to a SyntaxError.

A docstring is a valid string in python - and in the docstring,
"\*" was present in JavaGateway. Escape it correctly as \\*

Fixes https://github.com/bartdag/py4j/issues/377